### PR TITLE
feat: XML 데이터 포맷 전환 및 Edit/Skip 기능 추가 (#10)

### DIFF
--- a/app.py
+++ b/app.py
@@ -655,7 +655,7 @@ def read_file(path):
         return f.readlines()
 
 
-def make_row(rtype, lineno_a, lineno_b, text_a, text_b):
+def make_row(rtype, lineno_a, lineno_b, text_a, text_b, meta_b=None):
     """diff 테이블의 한 행(row) 데이터를 생성.
 
     행 유형에 따라 적절한 HTML을 생성:
@@ -671,15 +671,15 @@ def make_row(rtype, lineno_a, lineno_b, text_a, text_b):
         lineno_b (int|None): 수정본 줄 번호
         text_a (str|None): 원본 줄 텍스트
         text_b (str|None): 수정본 줄 텍스트
+        meta_b (dict|None): XML Item 메타데이터 (XML 파일의 replace/insert 행만 해당)
 
     Returns:
-        dict: {type, lineno_a, lineno_b, html_a, html_b}
+        dict: {type, lineno_a, lineno_b, html_a, html_b, meta_b}
     """
     if rtype == "equal":
         ha = esc(text_a)
         hb = esc(text_b)
     elif rtype == "replace":
-        # 단어 단위 diff로 세밀한 HTML 생성
         ha, hb = word_diff_html(text_a or "", text_b or "")
     elif rtype == "delete":
         ha = esc(text_a or "")
@@ -696,6 +696,7 @@ def make_row(rtype, lineno_a, lineno_b, text_a, text_b):
         "lineno_b": lineno_b,
         "html_a": ha,
         "html_b": hb,
+        "meta_b": meta_b,
     }
 
 

--- a/app.py
+++ b/app.py
@@ -17,7 +17,7 @@ import re      # 정규표현식 (토큰 분리, 공백 제거 등)
 import html    # HTML 이스케이프용
 import difflib # 텍스트 비교 및 유사도 계산 라이브러리
 import xml.etree.ElementTree as ET
-from flask import Flask, render_template, abort, redirect, url_for
+from flask import Flask, render_template, abort, redirect, url_for, request, jsonify
 
 # Flask 애플리케이션 인스턴스 생성
 app = Flask(__name__)
@@ -30,6 +30,9 @@ DATA_DIR = os.path.join(BASE_DIR, "data")
 # [H3] 두 줄이 같은 줄로 짝지어질 최소 유사도 임계값
 # 0.55로 설정 — 기존 0.3은 너무 낮아 무관한 줄끼리 잘못 매칭되는 문제가 있었음
 SIMILARITY_THRESHOLD = 0.55
+
+# 편집 결과를 전송할 외부 서버 URL (추후 설정)
+SUBMIT_SERVER_URL = ""
 
 
 # ─────────────────────────────────────────
@@ -854,10 +857,10 @@ def diff_view(baseline, filename):
 
     Args:
         baseline (str): URL에서 전달된 베이스라인 폴더명
-        filename (str): 비교할 파일명 (.txt만 허용)
+        filename (str): 비교할 파일명 (.xml만 허용)
     """
-    # .txt 확장자가 아닌 파일은 400 Bad Request
-    if not filename.endswith(".txt"):
+    # .xml 확장자가 아닌 파일은 400 Bad Request
+    if not filename.endswith(".xml"):
         abort(400)
 
     baselines = get_baselines()
@@ -879,6 +882,7 @@ def diff_view(baseline, filename):
     # 파일 목록 및 diff 데이터 생성
     files = get_file_list(baseline)
     rows, total, changed = build_diff(word_dir, code_dir, filename)
+    has_editable = any(r.get("meta_b") for r in rows)
     # 디렉토리 이름만 추출 (헤더 표시용)
     word_dir_name = os.path.basename(word_dir)
     code_dir_name = os.path.basename(code_dir)
@@ -894,7 +898,46 @@ def diff_view(baseline, filename):
         total=total,                   # 전체 행 수
         changed=changed,               # 변경된 행 수
         files=files,                   # 사이드바용 파일 목록
+        has_editable=has_editable,
     )
+
+
+@app.route("/<baseline>/diff/<filename>/submit", methods=["POST"])
+def submit_edits(baseline, filename):
+    """편집/스킵 처리된 diff 라인 데이터를 외부 서버로 전송.
+
+    Request body (JSON):
+        [{"package_name": str, "sub_title": str,
+          "item": {"id": str, "value": str, "line_number": int, "edit_type": str},
+          "user_action": "edited"|"skipped"}, ...]
+
+    Returns:
+        JSON: {"status": "ok", "count": int}
+    """
+    if baseline not in get_baselines():
+        abort(404)
+    if not filename.endswith(".xml"):
+        abort(400)
+
+    data = request.get_json()
+    if not isinstance(data, list):
+        abort(400)
+
+    if SUBMIT_SERVER_URL:
+        import urllib.request as urllib_req
+        import json as json_mod
+        payload = json_mod.dumps(data).encode("utf-8")
+        req = urllib_req.Request(
+            SUBMIT_SERVER_URL,
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib_req.urlopen(req, timeout=10) as resp:
+            pass
+        return jsonify({"status": "forwarded", "count": len(data)})
+
+    return jsonify({"status": "ok", "count": len(data)})
 
 
 # 직접 실행 시 Flask 개발 서버 시작 (디버그 모드)

--- a/app.py
+++ b/app.py
@@ -130,9 +130,9 @@ def get_file_list(baseline):
     # 한쪽에만 있는 파일도 포함하기 위해 set 합집합(|=) 사용
     filenames = set()
     if word_dir:
-        filenames |= {f for f in os.listdir(word_dir) if f.endswith(".txt")}
+        filenames |= {f for f in os.listdir(word_dir) if f.endswith(".xml")}
     if code_dir:
-        filenames |= {f for f in os.listdir(code_dir) if f.endswith(".txt")}
+        filenames |= {f for f in os.listdir(code_dir) if f.endswith(".xml")}
 
     # 각 파일의 변경 여부를 확인하여 리스트 구성
     files = []

--- a/app.py
+++ b/app.py
@@ -723,9 +723,15 @@ def build_diff(word_dir, code_dir, filename):
     path_a = os.path.join(word_dir, filename)
     path_b = os.path.join(code_dir, filename)
 
-    # [H1] Windows 줄바꿈(\r\n) 처리 — 통일된 비교를 위해 줄 끝 문자 제거
-    lines_a = [l.rstrip("\r\n") for l in read_file(path_a)]
-    lines_b = [l.rstrip("\r\n") for l in read_file(path_b)]
+    is_xml = filename.endswith(".xml")
+    if is_xml:
+        lines_a, _ = parse_xml_file(path_a)
+        lines_b, meta_map_b = parse_xml_file(path_b)
+    else:
+        # [H1] Windows 줄바꿈(\r\n) 처리 — 통일된 비교를 위해 줄 끝 문자 제거
+        lines_a = [l.rstrip("\r\n") for l in read_file(path_a)]
+        lines_b = [l.rstrip("\r\n") for l in read_file(path_b)]
+        meta_map_b = {}
 
     # [H2] 빈 파일 처리 — 양쪽 모두 비어있거나 한쪽만 빈 경우
     if not lines_a and not lines_b:
@@ -766,12 +772,19 @@ def build_diff(word_dir, code_dir, filename):
             # 변경된 줄 블록 — 유사도 기반 매칭으로 세밀하게 비교
             block_a = lines_a[i1:i2]
             block_b = lines_b[j1:j2]
-            matched = match_blocks(block_a, block_b)
+            if is_xml:
+                # XML 모드: 구조화된 항목은 위치 기준으로 강제 replace 매칭
+                matched = list(zip(["replace"] * max(len(block_a), len(block_b)),
+                                   block_a + [None] * (max(len(block_a), len(block_b)) - len(block_a)),
+                                   block_b + [None] * (max(len(block_a), len(block_b)) - len(block_b))))
+            else:
+                matched = match_blocks(block_a, block_b)
             for rtype, la, lb in matched:
                 # 해당 줄이 있을 때만 줄 번호 부여
                 lna = lineno_a if la is not None else None
                 lnb = lineno_b if lb is not None else None
-                rows.append(make_row(rtype, lna, lnb, la, lb))
+                meta = meta_map_b.get(lineno_b - 1) if (is_xml and lb is not None and rtype in ("replace", "insert")) else None
+                rows.append(make_row(rtype, lna, lnb, la, lb, meta_b=meta))
                 if la is not None: lineno_a += 1
                 if lb is not None: lineno_b += 1
 
@@ -784,7 +797,8 @@ def build_diff(word_dir, code_dir, filename):
         elif tag == "insert":
             # 추가된 줄 블록 — 수정본에만 존재하는 줄
             for lb in lines_b[j1:j2]:
-                rows.append(make_row("insert", None, lineno_b, None, lb))
+                meta = meta_map_b.get(lineno_b - 1) if is_xml else None
+                rows.append(make_row("insert", None, lineno_b, None, lb, meta_b=meta))
                 lineno_b += 1
 
     total   = len(rows)                                      # 전체 행 수

--- a/app.py
+++ b/app.py
@@ -16,6 +16,7 @@ import os      # 파일 시스템 경로 처리용
 import re      # 정규표현식 (토큰 분리, 공백 제거 등)
 import html    # HTML 이스케이프용
 import difflib # 텍스트 비교 및 유사도 계산 라이브러리
+import xml.etree.ElementTree as ET
 from flask import Flask, render_template, abort, redirect, url_for
 
 # Flask 애플리케이션 인스턴스 생성
@@ -590,6 +591,48 @@ def match_blocks(block_a, block_b):
 # ─────────────────────────────────────────
 # 파일 전체 diff: 두 파일을 비교하여 HTML 행 데이터 생성
 # ─────────────────────────────────────────
+
+def parse_xml_file(path):
+    """XML 파일을 파싱해 텍스트 라인 리스트와 Item 메타데이터 맵을 반환.
+
+    Returns:
+        tuple[list[str], dict[int, dict]]:
+            - lines: 기존 diff 엔진에 전달할 텍스트 라인 리스트
+              형식: ["######### {PackageName} ##########", "", "{Value}", ...]
+            - meta_map: {0-based 라인 인덱스: item 메타데이터 딕셔너리}
+              헤더/빈 줄은 meta_map에 포함되지 않음
+    """
+    tree = ET.parse(path)
+    root = tree.getroot()
+    package_name = root.findtext('PackageName') or ''
+
+    lines = []
+    meta_map = {}
+
+    for diff_item in root.findall('.//DiffItem'):
+        sub_title = diff_item.findtext('SubTitle') or ''
+        lines.append(f"######### {package_name} ##########")
+        lines.append("")
+
+        for item_el in diff_item.findall('Items/Item'):
+            item_id = item_el.findtext('ID') or ''
+            value = item_el.findtext('Value') or ''
+            line_number_text = item_el.findtext('LineNumber') or '0'
+            edit_type = item_el.findtext('EditType') or 'None'
+
+            idx = len(lines)
+            meta_map[idx] = {
+                'item_id': item_id,
+                'value': value,
+                'line_number': int(line_number_text),
+                'edit_type': edit_type,
+                'sub_title': sub_title,
+                'package_name': package_name,
+            }
+            lines.append(value)
+
+    return lines, meta_map
+
 
 def read_file(path):
     """파일을 UTF-8로 읽어 줄 리스트로 반환.

--- a/app.py
+++ b/app.py
@@ -933,7 +933,7 @@ def submit_edits(baseline, filename):
             headers={"Content-Type": "application/json"},
             method="POST",
         )
-        with urllib_req.urlopen(req, timeout=10) as resp:
+        with urllib_req.urlopen(req, timeout=10):
             pass
         return jsonify({"status": "forwarded", "count": len(data)})
 

--- a/app.py
+++ b/app.py
@@ -620,11 +620,16 @@ def parse_xml_file(path):
             line_number_text = item_el.findtext('LineNumber') or '0'
             edit_type = item_el.findtext('EditType') or 'None'
 
+            try:
+                line_number = int(line_number_text)
+            except ValueError:
+                line_number = 0
+
             idx = len(lines)
             meta_map[idx] = {
                 'item_id': item_id,
                 'value': value,
-                'line_number': int(line_number_text),
+                'line_number': line_number,
                 'edit_type': edit_type,
                 'sub_title': sub_title,
                 'package_name': package_name,

--- a/data/baseline_v4/00.WordBase/sample.xml
+++ b/data/baseline_v4/00.WordBase/sample.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DiffPackage>
+  <PackageName>TestPackage</PackageName>
+  <DiffItems>
+    <DiffItem>
+      <SubTitle>섹션A</SubTitle>
+      <Items>
+        <Item>
+          <ID>item_001</ID>
+          <Value>안녕하세요 세계</Value>
+          <LineNumber>1</LineNumber>
+          <EditType>None</EditType>
+        </Item>
+        <Item>
+          <ID>item_002</ID>
+          <Value>동일한 라인입니다</Value>
+          <LineNumber>2</LineNumber>
+          <EditType>None</EditType>
+        </Item>
+      </Items>
+    </DiffItem>
+    <DiffItem>
+      <SubTitle>섹션B</SubTitle>
+      <Items>
+        <Item>
+          <ID>item_003</ID>
+          <Value>변경될 내용 ABC</Value>
+          <LineNumber>3</LineNumber>
+          <EditType>None</EditType>
+        </Item>
+        <Item>
+          <ID>item_004</ID>
+          <Value>또 다른 동일 라인</Value>
+          <LineNumber>4</LineNumber>
+          <EditType>None</EditType>
+        </Item>
+      </Items>
+    </DiffItem>
+  </DiffItems>
+</DiffPackage>

--- a/data/baseline_v4/01.CodeBase/sample.xml
+++ b/data/baseline_v4/01.CodeBase/sample.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DiffPackage>
+  <PackageName>TestPackage</PackageName>
+  <DiffItems>
+    <DiffItem>
+      <SubTitle>섹션A</SubTitle>
+      <Items>
+        <Item>
+          <ID>item_001</ID>
+          <Value>안녕하세요 월드</Value>
+          <LineNumber>1</LineNumber>
+          <EditType>Modified</EditType>
+        </Item>
+        <Item>
+          <ID>item_002</ID>
+          <Value>동일한 라인입니다</Value>
+          <LineNumber>2</LineNumber>
+          <EditType>None</EditType>
+        </Item>
+      </Items>
+    </DiffItem>
+    <DiffItem>
+      <SubTitle>섹션B</SubTitle>
+      <Items>
+        <Item>
+          <ID>item_003</ID>
+          <Value>변경된 내용 XYZ</Value>
+          <LineNumber>3</LineNumber>
+          <EditType>Modified</EditType>
+        </Item>
+        <Item>
+          <ID>item_004</ID>
+          <Value>또 다른 동일 라인</Value>
+          <LineNumber>4</LineNumber>
+          <EditType>None</EditType>
+        </Item>
+      </Items>
+    </DiffItem>
+  </DiffItems>
+</DiffPackage>

--- a/docs/superpowers/plans/2026-04-29-xml-format-and-edit-feature.md
+++ b/docs/superpowers/plans/2026-04-29-xml-format-and-edit-feature.md
@@ -1,0 +1,1021 @@
+# XML 데이터 포맷 & Edit 기능 구현 계획
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `.txt` 파일을 `.xml` 포맷으로 교체하고, diff 화면에서 01.CodeBase 쪽 변경 라인에 Edit/Skip 기능을 추가하여 결과를 서버로 전송한다.
+
+**Architecture:** 백엔드에서 XML을 파싱해 기존 텍스트 포맷으로 변환 후 기존 diff 엔진에 그대로 전달한다. diff 행(row)에 XML Item 메타데이터를 함께 전달하고, 프론트엔드 JS가 편집 상태를 관리한 뒤 완료 시 JSON으로 서버에 전송한다.
+
+**Tech Stack:** Python 3 (xml.etree.ElementTree, Flask), pytest, Jinja2, Vanilla JS, CSS
+
+---
+
+## 변경 파일 목록
+
+| 파일 | 역할 |
+|------|------|
+| `app.py` | XML 파서 추가, 파일 확장자 `.xml` 처리, `meta_b` 전달, submit 엔드포인트 |
+| `templates/diff.html` | Edit/Skip 버튼, 진행 카운터, 전송 버튼, JS 상태 관리 |
+| `static/style.css` | 편집됨/스킵됨 상태 스타일, 버튼 스타일, 카운터/전송 버튼 스타일 |
+| `tests/test_xml_parser.py` | XML 파서 단위 테스트 |
+| `data/baseline_v4/00.WordBase/sample.xml` | XML 테스트 데이터 (원본) |
+| `data/baseline_v4/01.CodeBase/sample.xml` | XML 테스트 데이터 (수정본) |
+
+---
+
+## Task 1: XML 테스트 데이터 생성
+
+**Files:**
+- Create: `data/baseline_v4/00.WordBase/sample.xml`
+- Create: `data/baseline_v4/01.CodeBase/sample.xml`
+
+- [ ] **Step 1: 00.WordBase/sample.xml 생성**
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<DiffPackage>
+  <PackageName>TestPackage</PackageName>
+  <DiffItems>
+    <DiffItem>
+      <SubTitle>섹션A</SubTitle>
+      <Items>
+        <Item>
+          <ID>item_001</ID>
+          <Value>안녕하세요 세계</Value>
+          <LineNumber>1</LineNumber>
+          <EditType>None</EditType>
+        </Item>
+        <Item>
+          <ID>item_002</ID>
+          <Value>동일한 라인입니다</Value>
+          <LineNumber>2</LineNumber>
+          <EditType>None</EditType>
+        </Item>
+      </Items>
+    </DiffItem>
+    <DiffItem>
+      <SubTitle>섹션B</SubTitle>
+      <Items>
+        <Item>
+          <ID>item_003</ID>
+          <Value>변경될 내용 ABC</Value>
+          <LineNumber>3</LineNumber>
+          <EditType>None</EditType>
+        </Item>
+        <Item>
+          <ID>item_004</ID>
+          <Value>또 다른 동일 라인</Value>
+          <LineNumber>4</LineNumber>
+          <EditType>None</EditType>
+        </Item>
+      </Items>
+    </DiffItem>
+  </DiffItems>
+</DiffPackage>
+```
+
+- [ ] **Step 2: 01.CodeBase/sample.xml 생성 (일부 다른 내용)**
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<DiffPackage>
+  <PackageName>TestPackage</PackageName>
+  <DiffItems>
+    <DiffItem>
+      <SubTitle>섹션A</SubTitle>
+      <Items>
+        <Item>
+          <ID>item_001</ID>
+          <Value>안녕하세요 월드</Value>
+          <LineNumber>1</LineNumber>
+          <EditType>Modified</EditType>
+        </Item>
+        <Item>
+          <ID>item_002</ID>
+          <Value>동일한 라인입니다</Value>
+          <LineNumber>2</LineNumber>
+          <EditType>None</EditType>
+        </Item>
+      </Items>
+    </DiffItem>
+    <DiffItem>
+      <SubTitle>섹션B</SubTitle>
+      <Items>
+        <Item>
+          <ID>item_003</ID>
+          <Value>변경된 내용 XYZ</Value>
+          <LineNumber>3</LineNumber>
+          <EditType>Modified</EditType>
+        </Item>
+        <Item>
+          <ID>item_004</ID>
+          <Value>또 다른 동일 라인</Value>
+          <LineNumber>4</LineNumber>
+          <EditType>None</EditType>
+        </Item>
+      </Items>
+    </DiffItem>
+  </DiffItems>
+</DiffPackage>
+```
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add data/baseline_v4/
+git commit -m "test: add XML baseline_v4 test data"
+```
+
+---
+
+## Task 2: XML 파서 구현 (TDD)
+
+**Files:**
+- Create: `tests/test_xml_parser.py`
+- Modify: `app.py` (상단 import 및 `parse_xml_file` 함수 추가)
+
+- [ ] **Step 1: tests/ 디렉토리 및 테스트 파일 생성**
+
+```python
+# tests/test_xml_parser.py
+import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+import textwrap, tempfile, pytest
+from app import parse_xml_file
+
+XML_SAMPLE = textwrap.dedent("""\
+    <?xml version="1.0" encoding="utf-8"?>
+    <DiffPackage>
+      <PackageName>MyPkg</PackageName>
+      <DiffItems>
+        <DiffItem>
+          <SubTitle>섹션1</SubTitle>
+          <Items>
+            <Item>
+              <ID>id_001</ID>
+              <Value>첫 번째 값</Value>
+              <LineNumber>1</LineNumber>
+              <EditType>None</EditType>
+            </Item>
+            <Item>
+              <ID>id_002</ID>
+              <Value>두 번째 값</Value>
+              <LineNumber>2</LineNumber>
+              <EditType>Modified</EditType>
+            </Item>
+          </Items>
+        </DiffItem>
+        <DiffItem>
+          <SubTitle>섹션2</SubTitle>
+          <Items>
+            <Item>
+              <ID>id_003</ID>
+              <Value>세 번째 값</Value>
+              <LineNumber>3</LineNumber>
+              <EditType>None</EditType>
+            </Item>
+          </Items>
+        </DiffItem>
+      </DiffItems>
+    </DiffPackage>
+""")
+
+
+@pytest.fixture
+def xml_file(tmp_path):
+    f = tmp_path / "sample.xml"
+    f.write_text(XML_SAMPLE, encoding="utf-8")
+    return str(f)
+
+
+def test_parse_returns_tuple(xml_file):
+    result = parse_xml_file(xml_file)
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+
+
+def test_lines_contain_package_header(xml_file):
+    lines, _ = parse_xml_file(xml_file)
+    assert any("MyPkg" in l for l in lines)
+
+
+def test_lines_contain_all_item_values(xml_file):
+    lines, _ = parse_xml_file(xml_file)
+    assert "첫 번째 값" in lines
+    assert "두 번째 값" in lines
+    assert "세 번째 값" in lines
+
+
+def test_meta_map_keys_are_int(xml_file):
+    _, meta_map = parse_xml_file(xml_file)
+    for k in meta_map:
+        assert isinstance(k, int)
+
+
+def test_meta_map_item_fields(xml_file):
+    lines, meta_map = parse_xml_file(xml_file)
+    # 첫 번째 값이 있는 라인의 인덱스 찾기
+    idx = lines.index("첫 번째 값")
+    meta = meta_map[idx]
+    assert meta["item_id"] == "id_001"
+    assert meta["value"] == "첫 번째 값"
+    assert meta["line_number"] == 1
+    assert meta["edit_type"] == "None"
+    assert meta["sub_title"] == "섹션1"
+    assert meta["package_name"] == "MyPkg"
+
+
+def test_meta_map_second_diffitem(xml_file):
+    lines, meta_map = parse_xml_file(xml_file)
+    idx = lines.index("세 번째 값")
+    meta = meta_map[idx]
+    assert meta["item_id"] == "id_003"
+    assert meta["sub_title"] == "섹션2"
+
+
+def test_header_lines_not_in_meta_map(xml_file):
+    lines, meta_map = parse_xml_file(xml_file)
+    for idx, line in enumerate(lines):
+        if "MyPkg" in line or line.strip() == "":
+            assert idx not in meta_map, f"헤더/빈 줄(인덱스 {idx})이 meta_map에 포함됨"
+```
+
+- [ ] **Step 2: 테스트 실행 — 실패 확인**
+
+```
+cd /home/yangsm/Projects/diff-viewer
+pip install pytest -q
+pytest tests/test_xml_parser.py -v
+```
+
+Expected: FAIL (parse_xml_file not defined)
+
+- [ ] **Step 3: app.py 상단에 ET import 추가**
+
+`app.py` 15~18번째 줄 import 블록에 아래 추가:
+```python
+import xml.etree.ElementTree as ET
+```
+
+- [ ] **Step 4: parse_xml_file 함수 추가**
+
+`app.py` 의 `read_file` 함수(594번째 줄) 바로 위에 추가:
+
+```python
+def parse_xml_file(path):
+    """XML 파일을 파싱해 텍스트 라인 리스트와 Item 메타데이터 맵을 반환.
+
+    Returns:
+        tuple[list[str], dict[int, dict]]:
+            - lines: 기존 diff 엔진에 전달할 텍스트 라인 리스트
+              형식: ["######### {PackageName} ##########", "", "{Value}", ...]
+            - meta_map: {0-based 라인 인덱스: item 메타데이터 딕셔너리}
+              헤더/빈 줄은 meta_map에 포함되지 않음
+    """
+    tree = ET.parse(path)
+    root = tree.getroot()
+    package_name = root.findtext('PackageName') or ''
+
+    lines = []
+    meta_map = {}
+
+    for diff_item in root.findall('.//DiffItem'):
+        sub_title = diff_item.findtext('SubTitle') or ''
+        lines.append(f"######### {package_name} ##########")
+        lines.append("")
+
+        for item_el in diff_item.findall('Items/Item'):
+            item_id = item_el.findtext('ID') or ''
+            value = item_el.findtext('Value') or ''
+            line_number_text = item_el.findtext('LineNumber') or '0'
+            edit_type = item_el.findtext('EditType') or 'None'
+
+            idx = len(lines)
+            meta_map[idx] = {
+                'item_id': item_id,
+                'value': value,
+                'line_number': int(line_number_text),
+                'edit_type': edit_type,
+                'sub_title': sub_title,
+                'package_name': package_name,
+            }
+            lines.append(value)
+
+    return lines, meta_map
+```
+
+- [ ] **Step 5: 테스트 실행 — 통과 확인**
+
+```
+pytest tests/test_xml_parser.py -v
+```
+
+Expected: 모든 테스트 PASS
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add app.py tests/test_xml_parser.py
+git commit -m "feat: add parse_xml_file with tests"
+```
+
+---
+
+## Task 3: 파일 스캔 함수 XML 확장자 처리
+
+**Files:**
+- Modify: `app.py` (`get_file_list` 함수, 132~134번째 줄)
+
+- [ ] **Step 1: 실패 테스트 추가 (tests/test_xml_parser.py 하단에 추가)**
+
+```python
+# tests/test_xml_parser.py 하단에 추가
+from app import get_file_list
+
+def test_get_file_list_finds_xml(tmp_path):
+    # baseline 디렉토리 구조 생성
+    word_dir = tmp_path / "00.WordBase"
+    code_dir = tmp_path / "01.CodeBase"
+    word_dir.mkdir(); code_dir.mkdir()
+    (word_dir / "a.xml").write_text("<DiffPackage><PackageName>P</PackageName><DiffItems/></DiffPackage>")
+    (code_dir / "a.xml").write_text("<DiffPackage><PackageName>P</PackageName><DiffItems/></DiffPackage>")
+
+    import app as app_module
+    original_data_dir = app_module.DATA_DIR
+
+    # baseline 디렉토리를 tmp_path 기준으로 임시 교체
+    baseline_name = tmp_path.name
+    parent = str(tmp_path.parent)
+    app_module.DATA_DIR = parent
+    try:
+        result = get_file_list(baseline_name)
+        filenames = [f['name'] for f in result['files']]
+        assert "a.xml" in filenames
+    finally:
+        app_module.DATA_DIR = original_data_dir
+```
+
+- [ ] **Step 2: 테스트 실행 — 실패 확인**
+
+```
+pytest tests/test_xml_parser.py::test_get_file_list_finds_xml -v
+```
+
+Expected: FAIL (`.txt` 필터로 인해 `a.xml`을 찾지 못함)
+
+- [ ] **Step 3: get_file_list 함수 수정 (app.py 132~134번째 줄)**
+
+변경 전:
+```python
+    if word_dir:
+        filenames |= {f for f in os.listdir(word_dir) if f.endswith(".txt")}
+    if code_dir:
+        filenames |= {f for f in os.listdir(code_dir) if f.endswith(".txt")}
+```
+
+변경 후:
+```python
+    if word_dir:
+        filenames |= {f for f in os.listdir(word_dir) if f.endswith(".xml")}
+    if code_dir:
+        filenames |= {f for f in os.listdir(code_dir) if f.endswith(".xml")}
+```
+
+- [ ] **Step 4: 테스트 실행 — 통과 확인**
+
+```
+pytest tests/test_xml_parser.py -v
+```
+
+Expected: 모든 테스트 PASS
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app.py tests/test_xml_parser.py
+git commit -m "feat: update file scanning to .xml extension"
+```
+
+---
+
+## Task 4: make_row에 meta_b 필드 추가
+
+**Files:**
+- Modify: `app.py` (`make_row` 함수, 610~651번째 줄)
+
+- [ ] **Step 1: make_row 시그니처 및 반환값 수정**
+
+`app.py` 610번째 줄 `make_row` 함수 전체를 아래로 교체:
+
+```python
+def make_row(rtype, lineno_a, lineno_b, text_a, text_b, meta_b=None):
+    """diff 테이블의 한 행(row) 데이터를 생성.
+
+    Args:
+        rtype (str): 행 유형 ("equal", "replace", "delete", "insert", "empty-file")
+        lineno_a (int|None): 원본 줄 번호
+        lineno_b (int|None): 수정본 줄 번호
+        text_a (str|None): 원본 줄 텍스트
+        text_b (str|None): 수정본 줄 텍스트
+        meta_b (dict|None): XML Item 메타데이터 (XML 파일의 replace/insert 행만 해당)
+
+    Returns:
+        dict: {type, lineno_a, lineno_b, html_a, html_b, meta_b}
+    """
+    if rtype == "equal":
+        ha = esc(text_a)
+        hb = esc(text_b)
+    elif rtype == "replace":
+        ha, hb = word_diff_html(text_a or "", text_b or "")
+    elif rtype == "delete":
+        ha = esc(text_a or "")
+        hb = ""
+    elif rtype == "empty-file":
+        ha = ""
+        hb = ""
+    else:  # insert
+        ha = ""
+        hb = esc(text_b or "")
+    return {
+        "type": rtype,
+        "lineno_a": lineno_a,
+        "lineno_b": lineno_b,
+        "html_a": ha,
+        "html_b": hb,
+        "meta_b": meta_b,
+    }
+```
+
+- [ ] **Step 2: 커밋**
+
+```bash
+git add app.py
+git commit -m "feat: add meta_b field to make_row"
+```
+
+---
+
+## Task 5: build_diff에 XML 파싱 연동
+
+**Files:**
+- Modify: `app.py` (`build_diff` 함수, 654~743번째 줄)
+
+- [ ] **Step 1: 실패 테스트 추가 (tests/test_xml_parser.py 하단에 추가)**
+
+```python
+# tests/test_xml_parser.py 하단에 추가
+from app import build_diff
+
+WORD_XML = """<?xml version="1.0" encoding="utf-8"?>
+<DiffPackage>
+  <PackageName>Pkg</PackageName>
+  <DiffItems>
+    <DiffItem>
+      <SubTitle>S1</SubTitle>
+      <Items>
+        <Item><ID>a1</ID><Value>같은 내용</Value><LineNumber>1</LineNumber><EditType>None</EditType></Item>
+        <Item><ID>a2</ID><Value>원본 값</Value><LineNumber>2</LineNumber><EditType>None</EditType></Item>
+      </Items>
+    </DiffItem>
+  </DiffItems>
+</DiffPackage>"""
+
+CODE_XML = """<?xml version="1.0" encoding="utf-8"?>
+<DiffPackage>
+  <PackageName>Pkg</PackageName>
+  <DiffItems>
+    <DiffItem>
+      <SubTitle>S1</SubTitle>
+      <Items>
+        <Item><ID>a1</ID><Value>같은 내용</Value><LineNumber>1</LineNumber><EditType>None</EditType></Item>
+        <Item><ID>a2</ID><Value>수정된 값</Value><LineNumber>2</LineNumber><EditType>Modified</EditType></Item>
+      </Items>
+    </DiffItem>
+  </DiffItems>
+</DiffPackage>"""
+
+
+def test_build_diff_xml_replace_has_meta_b(tmp_path):
+    word_dir = tmp_path / "00.WordBase"
+    code_dir = tmp_path / "01.CodeBase"
+    word_dir.mkdir(); code_dir.mkdir()
+    (word_dir / "t.xml").write_text(WORD_XML, encoding="utf-8")
+    (code_dir / "t.xml").write_text(CODE_XML, encoding="utf-8")
+
+    rows, total, changed = build_diff(str(word_dir), str(code_dir), "t.xml")
+    replace_rows = [r for r in rows if r["type"] == "replace"]
+    assert len(replace_rows) > 0
+    for row in replace_rows:
+        assert row["meta_b"] is not None
+        assert "item_id" in row["meta_b"]
+        assert "sub_title" in row["meta_b"]
+        assert "package_name" in row["meta_b"]
+
+
+def test_build_diff_xml_equal_has_no_meta_b(tmp_path):
+    word_dir = tmp_path / "00.WordBase"
+    code_dir = tmp_path / "01.CodeBase"
+    word_dir.mkdir(); code_dir.mkdir()
+    (word_dir / "t.xml").write_text(WORD_XML, encoding="utf-8")
+    (code_dir / "t.xml").write_text(CODE_XML, encoding="utf-8")
+
+    rows, _, _ = build_diff(str(word_dir), str(code_dir), "t.xml")
+    equal_rows = [r for r in rows if r["type"] == "equal"]
+    assert len(equal_rows) > 0
+    for row in equal_rows:
+        assert row["meta_b"] is None
+```
+
+- [ ] **Step 2: 테스트 실행 — 실패 확인**
+
+```
+pytest tests/test_xml_parser.py::test_build_diff_xml_replace_has_meta_b tests/test_xml_parser.py::test_build_diff_xml_equal_has_no_meta_b -v
+```
+
+Expected: FAIL
+
+- [ ] **Step 3: build_diff 함수 수정**
+
+`app.py` `build_diff` 함수에서 파일 읽는 부분(677~679번째 줄)을 아래로 교체:
+
+```python
+    is_xml = filename.endswith(".xml")
+    if is_xml:
+        lines_a, _ = parse_xml_file(path_a)
+        lines_b, meta_map_b = parse_xml_file(path_b)
+    else:
+        lines_a = [l.rstrip("\r\n") for l in read_file(path_a)]
+        lines_b = [l.rstrip("\r\n") for l in read_file(path_b)]
+        meta_map_b = {}
+```
+
+그리고 `build_diff` 내부 `replace` 블록 처리 부분(721~727번째 줄)을 수정:
+
+```python
+            for rtype, la, lb in matched:
+                lna = lineno_a if la is not None else None
+                lnb = lineno_b if lb is not None else None
+                meta = meta_map_b.get(lineno_b - 1) if (is_xml and lb is not None and rtype in ("replace", "insert")) else None
+                rows.append(make_row(rtype, lna, lnb, la, lb, meta_b=meta))
+                if la is not None: lineno_a += 1
+                if lb is not None: lineno_b += 1
+```
+
+그리고 `insert` 블록 처리 부분(735~738번째 줄)을 수정:
+
+```python
+        elif tag == "insert":
+            for lb in lines_b[j1:j2]:
+                meta = meta_map_b.get(lineno_b - 1) if is_xml else None
+                rows.append(make_row("insert", None, lineno_b, None, lb, meta_b=meta))
+                lineno_b += 1
+```
+
+- [ ] **Step 4: 테스트 실행 — 통과 확인**
+
+```
+pytest tests/test_xml_parser.py -v
+```
+
+Expected: 모든 테스트 PASS
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app.py tests/test_xml_parser.py
+git commit -m "feat: connect build_diff with XML parser and meta_b"
+```
+
+---
+
+## Task 6: diff_view 라우트 XML 확장자 처리
+
+**Files:**
+- Modify: `app.py` (`diff_view` 함수, 796~797번째 줄)
+
+- [ ] **Step 1: diff_view 파일 확장자 체크 수정**
+
+변경 전 (796~797번째 줄):
+```python
+    if not filename.endswith(".txt"):
+        abort(400)
+```
+
+변경 후:
+```python
+    if not filename.endswith(".xml"):
+        abort(400)
+```
+
+- [ ] **Step 2: Flask 서버 실행 후 브라우저에서 확인**
+
+```
+python app.py
+```
+
+브라우저에서 `http://localhost:5000/baseline_v4` 접속 → `sample.xml` 목록 확인 → 클릭하여 diff 화면 정상 표시 여부 확인.
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add app.py
+git commit -m "feat: update diff_view route to accept .xml files"
+```
+
+---
+
+## Task 7: 서버 전송 엔드포인트 추가
+
+**Files:**
+- Modify: `app.py` (import 블록 및 `diff_view` 라우트 아래에 추가)
+
+- [ ] **Step 1: Flask request, jsonify import 추가**
+
+`app.py` 19번째 줄 import 수정:
+
+```python
+from flask import Flask, render_template, abort, redirect, url_for, request, jsonify
+```
+
+- [ ] **Step 2: 서버 전송 URL 상수 추가**
+
+`app.py` `SIMILARITY_THRESHOLD` 상수(31번째 줄) 바로 아래에 추가:
+
+```python
+# 편집 결과를 전송할 외부 서버 URL (추후 설정)
+SUBMIT_SERVER_URL = ""
+```
+
+- [ ] **Step 3: submit 엔드포인트 추가**
+
+`app.py` 맨 끝 `if __name__ == "__main__":` 블록 바로 위에 추가:
+
+```python
+@app.route("/<baseline>/diff/<filename>/submit", methods=["POST"])
+def submit_edits(baseline, filename):
+    """편집/스킵 처리된 diff 라인 데이터를 외부 서버로 전송.
+
+    Request body (JSON):
+        [{"package_name": str, "sub_title": str,
+          "item": {"id": str, "value": str, "line_number": int, "edit_type": str},
+          "user_action": "edited"|"skipped"}, ...]
+
+    Returns:
+        JSON: {"status": "ok", "count": int} 또는
+              {"status": "forwarded", "count": int} (서버 URL 설정 시)
+    """
+    if baseline not in get_baselines():
+        abort(404)
+    if not filename.endswith(".xml"):
+        abort(400)
+
+    data = request.get_json()
+    if not isinstance(data, list):
+        abort(400)
+
+    if SUBMIT_SERVER_URL:
+        import urllib.request as urllib_req
+        import json as json_mod
+        payload = json_mod.dumps(data).encode("utf-8")
+        req = urllib_req.Request(
+            SUBMIT_SERVER_URL,
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib_req.urlopen(req, timeout=10) as resp:
+            pass
+        return jsonify({"status": "forwarded", "count": len(data)})
+
+    return jsonify({"status": "ok", "count": len(data)})
+```
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add app.py
+git commit -m "feat: add submit_edits endpoint for server forwarding"
+```
+
+---
+
+## Task 8: diff.html 템플릿 수정 (Edit/Skip UI)
+
+**Files:**
+- Modify: `templates/diff.html`
+
+- [ ] **Step 1: 헤더에 진행 카운터 및 전송 버튼 추가**
+
+`diff.html` 26번째 줄 `{% if changed > 0 %}` 블록 안에, 네비게이션 버튼들 바로 앞에 추가:
+
+```html
+      <!-- XML 편집 진행 카운터 + 전송 버튼 (XML 파일이고 변경이 있을 때만) -->
+      {% if rows and rows[0].meta_b is not none or rows | selectattr('meta_b') | list %}
+      <span class="edit-progress" id="edit-progress">0 / 0 처리됨</span>
+      <button class="send-btn" id="send-btn" disabled>서버로 전송</button>
+      {% endif %}
+```
+
+실제로는 Jinja2에서 `rows|selectattr` 필터가 복잡하므로, `diff_view`에서 `has_editable` 변수를 전달하는 방식으로 변경. 먼저 `app.py`의 `diff_view` 반환값에 추가:
+
+`app.py` `diff_view` 함수의 `render_template` 호출(823번째 줄)에 파라미터 추가:
+
+```python
+    has_editable = any(r.get("meta_b") for r in rows)
+
+    return render_template(
+        "diff.html",
+        baselines=baselines,
+        current_baseline=baseline,
+        filename=filename,
+        word_dir_name=word_dir_name,
+        code_dir_name=code_dir_name,
+        rows=rows,
+        total=total,
+        changed=changed,
+        files=files,
+        has_editable=has_editable,
+    )
+```
+
+그런 다음 `diff.html` 26번째 줄 `{% if changed > 0 %}` 안에 추가:
+
+```html
+      {% if has_editable %}
+      <span class="edit-progress" id="edit-progress">0 / {{ changed }} 처리됨</span>
+      <button class="send-btn" id="send-btn" disabled>서버로 전송</button>
+      {% endif %}
+```
+
+- [ ] **Step 2: diff 테이블 replace/insert 행의 code-b 셀에 Edit/Skip 버튼 추가**
+
+`diff.html` 82번째 줄의 `code-b` 셀 부분을 아래로 교체:
+
+```html
+        <!-- 수정본 코드: 추가/변경 시 '+' 기호 표시 + 단어 단위 diff HTML -->
+        <td class="code code-b">
+          <span class="line-mark {% if row.type == "insert" or row.type == "replace" %}line-mark-add{% endif %}">{% if row.type == "insert" or row.type == "replace" %}+{% endif %}</span>
+          <span class="line-text" id="line-text-{{ loop.index }}">{{ row.html_b|safe }}</span>
+          {% if row.meta_b %}
+          <span class="edit-actions">
+            <button class="edit-action-btn edit-btn" data-row="{{ loop.index }}"
+              data-meta="{{ row.meta_b | tojson | forceescape }}"
+              data-original="{{ row.meta_b.value | e }}">수정</button>
+            <button class="edit-action-btn skip-btn" data-row="{{ loop.index }}"
+              data-meta="{{ row.meta_b | tojson | forceescape }}">스킵</button>
+          </span>
+          <span class="edit-status-badge" id="badge-{{ loop.index }}" style="display:none"></span>
+          {% endif %}
+        </td>
+```
+
+- [ ] **Step 3: JS 상태 관리 스크립트 추가**
+
+`diff.html` 기존 `<script>` 블록 내부 맨 끝(`}());` 바로 뒤)에 추가:
+
+```javascript
+/* ── Edit/Skip 상태 관리 ── */
+(function() {
+  var editState = {};  // { rowIndex: { action: "edited"|"skipped", value: str, meta: obj } }
+  var totalEditable = document.querySelectorAll('[data-meta]').length / 2;  // 버튼 쌍
+  var progressEl = document.getElementById('edit-progress');
+  var sendBtn = document.getElementById('send-btn');
+
+  function updateProgress() {
+    var done = Object.keys(editState).length;
+    if (progressEl) progressEl.textContent = done + ' / ' + totalEditable + ' 처리됨';
+    if (sendBtn) sendBtn.disabled = (done < totalEditable);
+  }
+
+  function setRowState(rowIdx, action, value, meta) {
+    var row = document.querySelector('tr:nth-child(' + rowIdx + ')') ||
+              document.querySelector('[data-row="' + rowIdx + '"]').closest('tr');
+    var badge = document.getElementById('badge-' + rowIdx);
+    var lineText = document.getElementById('line-text-' + rowIdx);
+
+    // 기존 상태 초기화
+    row.classList.remove('row-edited', 'row-skipped');
+    if (badge) { badge.style.display = 'none'; badge.textContent = ''; }
+
+    if (action === null) {
+      delete editState[rowIdx];
+    } else {
+      editState[rowIdx] = { action: action, value: value, meta: meta };
+      row.classList.add(action === 'edited' ? 'row-edited' : 'row-skipped');
+      if (badge) {
+        badge.textContent = action === 'edited' ? '✓ 수정됨' : '⊘ 스킵됨';
+        badge.className = 'edit-status-badge badge-' + (action === 'edited' ? 'edited' : 'skipped');
+        badge.style.display = 'inline';
+      }
+      if (action === 'edited' && lineText) lineText.textContent = value;
+    }
+    updateProgress();
+  }
+
+  // 수정 버튼 클릭
+  document.querySelectorAll('.edit-btn').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      var rowIdx = this.getAttribute('data-row');
+      var meta = JSON.parse(this.getAttribute('data-meta'));
+      var original = this.getAttribute('data-original');
+
+      if (editState[rowIdx] && editState[rowIdx].action === 'edited') {
+        setRowState(rowIdx, null, null, null);
+        return;
+      }
+
+      var newVal = prompt('값을 수정하세요:', original);
+      if (newVal === null) return;  // 취소
+      setRowState(rowIdx, 'edited', newVal, meta);
+    });
+  });
+
+  // 스킵 버튼 클릭
+  document.querySelectorAll('.skip-btn').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      var rowIdx = this.getAttribute('data-row');
+      var meta = JSON.parse(this.getAttribute('data-meta'));
+      var original = document.getElementById('line-text-' + rowIdx) ?
+                     document.getElementById('line-text-' + rowIdx).textContent : '';
+
+      if (editState[rowIdx] && editState[rowIdx].action === 'skipped') {
+        setRowState(rowIdx, null, null, null);
+        return;
+      }
+      setRowState(rowIdx, 'skipped', original, meta);
+    });
+  });
+
+  // 서버 전송 버튼 클릭
+  if (sendBtn) {
+    sendBtn.addEventListener('click', function() {
+      var payload = Object.values(editState).map(function(s) {
+        return {
+          package_name: s.meta.package_name,
+          sub_title: s.meta.sub_title,
+          item: {
+            id: s.meta.item_id,
+            value: s.value,
+            line_number: s.meta.line_number,
+            edit_type: s.meta.edit_type
+          },
+          user_action: s.action
+        };
+      });
+
+      var url = window.location.pathname + '/submit';
+      fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      })
+      .then(function(r) { return r.json(); })
+      .then(function(data) {
+        alert('전송 완료: ' + data.count + '건');
+      })
+      .catch(function(err) {
+        alert('전송 실패: ' + err.message);
+      });
+    });
+  }
+
+  updateProgress();
+}());
+```
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add templates/diff.html app.py
+git commit -m "feat: add Edit/Skip UI and server submit to diff.html"
+```
+
+---
+
+## Task 9: CSS 스타일 추가
+
+**Files:**
+- Modify: `static/style.css` (파일 끝에 추가)
+
+- [ ] **Step 1: style.css 파일 끝에 스타일 추가**
+
+```css
+/* ── Edit/Skip 기능 스타일 ── */
+
+.edit-actions {
+  display: inline-flex;
+  gap: 4px;
+  margin-left: 8px;
+  vertical-align: middle;
+}
+
+.edit-action-btn {
+  font-size: 11px;
+  padding: 1px 7px;
+  border-radius: 3px;
+  border: 1px solid currentColor;
+  cursor: pointer;
+  background: transparent;
+  line-height: 1.4;
+}
+
+.edit-btn {
+  color: #2563eb;
+  border-color: #93c5fd;
+}
+.edit-btn:hover { background: #eff6ff; }
+
+.skip-btn {
+  color: #6b7280;
+  border-color: #d1d5db;
+}
+.skip-btn:hover { background: #f9fafb; }
+
+/* 수정됨 상태 행 */
+tr.row-edited td { background: #f0fdf4 !important; }
+tr.row-edited td.code-b { outline: 2px solid #22c55e; outline-offset: -2px; }
+
+/* 스킵됨 상태 행 */
+tr.row-skipped td { background: #f9fafb !important; opacity: 0.7; }
+tr.row-skipped td.code-b { outline: 2px solid #9ca3af; outline-offset: -2px; }
+
+/* 상태 뱃지 */
+.edit-status-badge {
+  font-size: 11px;
+  font-weight: 600;
+  margin-left: 6px;
+  padding: 1px 5px;
+  border-radius: 3px;
+  vertical-align: middle;
+}
+.badge-edited  { color: #15803d; background: #dcfce7; }
+.badge-skipped { color: #6b7280; background: #f3f4f6; }
+
+/* 진행 카운터 */
+.edit-progress {
+  font-size: 12px;
+  color: #6b7280;
+  margin-right: 6px;
+}
+
+/* 서버 전송 버튼 */
+.send-btn {
+  font-size: 12px;
+  padding: 3px 12px;
+  border-radius: 4px;
+  border: 1px solid #2563eb;
+  background: #2563eb;
+  color: #fff;
+  cursor: pointer;
+  font-weight: 600;
+}
+.send-btn:disabled {
+  background: #9ca3af;
+  border-color: #9ca3af;
+  cursor: not-allowed;
+}
+.send-btn:not(:disabled):hover { background: #1d4ed8; }
+```
+
+- [ ] **Step 2: 커밋**
+
+```bash
+git add static/style.css
+git commit -m "feat: add CSS styles for Edit/Skip feature"
+```
+
+---
+
+## Task 10: 최종 통합 테스트
+
+- [ ] **Step 1: 전체 테스트 실행**
+
+```
+pytest tests/ -v
+```
+
+Expected: 모든 테스트 PASS
+
+- [ ] **Step 2: Flask 서버 실행 후 브라우저 E2E 테스트**
+
+```
+python app.py
+```
+
+체크리스트:
+- `http://localhost:5000/baseline_v4` → `sample.xml` 목록 표시 확인
+- `sample.xml` 클릭 → diff 화면 표시 확인
+- 변경된 행에 [수정] / [스킵] 버튼 표시 확인
+- [수정] 클릭 → 프롬프트 입력 → 행이 초록 테두리 + ✓ 수정됨 뱃지로 변경 확인
+- [스킵] 클릭 → 행이 회색 테두리 + ⊘ 스킵됨 뱃지로 변경 확인
+- 버튼 재클릭 → 원래 상태로 복귀 확인
+- 모든 diff 행 처리 후 "서버로 전송" 버튼 활성화 확인
+- 전송 버튼 클릭 → "전송 완료: N건" 알림 확인
+
+- [ ] **Step 3: 최종 커밋 (필요 시)**
+
+```bash
+git add -A
+git commit -m "chore: finalize XML format and edit feature implementation"
+```

--- a/docs/superpowers/specs/2026-04-29-xml-format-and-edit-feature-design.md
+++ b/docs/superpowers/specs/2026-04-29-xml-format-and-edit-feature-design.md
@@ -1,0 +1,183 @@
+# XML 데이터 포맷 & Edit 기능 추가 설계
+
+**날짜**: 2026-04-29  
+**이슈**: #10 — 데이터 포맷 및 기능 추가  
+**방식**: 방식 A (백엔드 XML 파싱 + 프론트엔드 편집 상태 관리)
+
+---
+
+## 1. 배경 및 목표
+
+- 기존 `.txt` 파일 포맷을 `.xml` 포맷으로 **완전 교체**
+- `00.WordBase` / `01.CodeBase` 디렉토리 내 파일이 모두 XML로 변경됨
+- 기존 diff 비교 로직은 그대로 유지하면서 XML을 텍스트로 변환하여 활용
+- `01.CodeBase` 쪽의 diff 라인에 **Edit/Skip** 기능 추가
+- 모든 diff 라인 처리 완료 시 서버로 JSON 전송
+
+---
+
+## 2. XML 데이터 구조
+
+```xml
+<DiffPackage>
+  <PackageName>패키지명</PackageName>
+  <DiffItems>
+    <DiffItem>
+      <SubTitle>소제목</SubTitle>
+      <Items>
+        <Item>
+          <ID>아이템ID</ID>
+          <Value>텍스트값</Value>
+          <LineNumber>5</LineNumber>
+          <EditType>None</EditType>
+        </Item>
+        ...
+      </Items>
+    </DiffItem>
+    ...
+  </DiffItems>
+</DiffPackage>
+```
+
+- `EditType`은 XML 데이터가 가진 고유 필드이며, 사용자가 제어하는 값이 아님
+- 모든 `Item`의 `Value`가 변환 대상 (EditType 무관)
+
+---
+
+## 3. 백엔드 설계 (app.py)
+
+### 3-1. 파일 감지
+
+- `get_file_list()`, `file_has_diff()`: `.txt` → `.xml` 확장자로 변경
+- XML 파일 여부는 확장자로 판별
+
+### 3-2. XML 파싱 함수 (`parse_xml_file`)
+
+XML을 파싱하여 두 가지 결과물 반환:
+
+**① 텍스트 라인 리스트** (기존 diff 엔진 입력용)
+
+```
+######### {PackageName} ##########
+
+{Item.Value}
+{Item.Value}
+...
+```
+
+- PackageName 헤더 행 다음에 모든 Item의 Value를 순서대로 나열
+- 기존 `read_file()` 역할을 대체
+
+**② 메타데이터 맵**
+
+```python
+{
+  라인인덱스(int): {
+    "item_id": str,
+    "value": str,
+    "line_number": int,
+    "edit_type": str,
+    "sub_title": str,
+    "package_name": str,
+  }
+}
+```
+
+- 텍스트 라인 인덱스 기준으로 Item 메타데이터를 조회할 수 있는 딕셔너리
+- 헤더 행(PackageName 행)은 메타데이터 없음
+
+### 3-3. diff 행(row) 확장
+
+- `build_diff()` 로직 변경 없음 — 텍스트 라인만 받으므로 기존 그대로 동작
+- `make_row()` 에서 XML 파일일 경우 `meta_b` 필드 추가:
+  - `replace` / `insert` 타입 행에만 포함
+  - `meta_b`: 해당 행의 01.CodeBase Item 메타데이터 딕셔너리
+- 템플릿으로 전달 시 각 row에 `meta_b` 포함
+
+---
+
+## 4. 프론트엔드 설계 (diff.html + JS)
+
+### 4-1. Edit/Skip 버튼
+
+- `replace` 타입 행의 `01.CodeBase` 셀에 버튼 두 개 표시:
+  - `[Edit]`: 클릭 시 셀 내용이 `<textarea>`로 전환 → 저장 시 "편집됨" 상태
+  - `[Skip]`: 클릭 시 즉시 "스킵됨" 상태
+
+### 4-2. 상태 시각화
+
+| 상태 | 표시 |
+|------|------|
+| 미처리 | 기본 diff 스타일 |
+| 편집됨 | 초록 테두리 + ✓ 뱃지 |
+| 스킵됨 | 회색 테두리 + ⊘ 뱃지 |
+
+- 두 상태 모두 다시 클릭(또는 버튼 재선택)하면 원래 상태로 되돌리기 가능
+
+### 4-3. 진행 카운터 & 전송 버튼
+
+- 헤더 영역에 `"3 / 7 처리됨"` 형태 카운터 표시
+- 모든 diff 행이 편집됨 또는 스킵됨 상태가 되면 **"서버로 전송"** 버튼 활성화
+- 버튼 활성화 전에는 비활성화(disabled) 처리
+
+### 4-4. 상태 관리 (JS)
+
+```javascript
+// Map<rowIndex, { action: "edited"|"skipped", value: string }>
+const editState = new Map();
+```
+
+- 페이지 새로고침 시 초기화 (의도된 트레이드오프)
+
+### 4-5. 전송 데이터 (JSON)
+
+변경된(다른) 라인만 전송:
+
+```json
+[
+  {
+    "package_name": "패키지명",
+    "sub_title": "소제목",
+    "item": {
+      "id": "아이템ID",
+      "value": "수정된값 또는 원래값",
+      "line_number": 5,
+      "edit_type": "None"
+    },
+    "user_action": "edited"
+  },
+  {
+    "package_name": "패키지명",
+    "sub_title": "소제목",
+    "item": {
+      "id": "아이템ID",
+      "value": "원래값",
+      "line_number": 8,
+      "edit_type": "None"
+    },
+    "user_action": "skipped"
+  }
+]
+```
+
+- `edited` 행: `item.value`는 사용자가 수정한 값
+- `skipped` 행: `item.value`는 원래 XML의 Value
+- 전송 서버 URL은 추후 기입
+
+---
+
+## 5. 변경 파일 목록
+
+| 파일 | 변경 내용 |
+|------|-----------|
+| `app.py` | XML 파싱 함수 추가, 파일 확장자 처리, row에 meta_b 추가 |
+| `templates/diff.html` | Edit/Skip 버튼, 상태 뱃지, 진행 카운터, 전송 버튼 |
+| `static/style.css` | 편집됨/스킵됨 상태 스타일 추가 |
+
+---
+
+## 6. 제약사항 및 트레이드오프
+
+- 페이지 새로고침 시 편집 상태 초기화 (세션 저장 미구현)
+- 서버 전송 URL은 추후 별도 설정
+- `.txt` 파일 지원 완전 제거 (하위 호환 없음)

--- a/static/style.css
+++ b/static/style.css
@@ -747,3 +747,64 @@ span.wd-ws-add {
   .diff-col-header { grid-template-columns: 40px 1fr 40px 1fr; }  /* 거터 너비 축소 */
   .gutter { width: 40px; min-width: 40px; max-width: 40px; }
 }
+
+/* ── Edit/Skip 기능 스타일 ── */
+
+.edit-actions {
+  display: inline-flex;
+  gap: 4px;
+  margin-left: 8px;
+  vertical-align: middle;
+}
+
+.edit-action-btn {
+  font-size: 11px;
+  padding: 1px 7px;
+  border-radius: 3px;
+  border: 1px solid currentColor;
+  cursor: pointer;
+  background: transparent;
+  line-height: 1.4;
+}
+
+.edit-btn { color: #2563eb; border-color: #93c5fd; }
+.edit-btn:hover { background: #eff6ff; }
+
+.skip-btn { color: #6b7280; border-color: #d1d5db; }
+.skip-btn:hover { background: #f9fafb; }
+
+tr.row-edited td { background: #f0fdf4 !important; }
+tr.row-edited td.code-b { outline: 2px solid #22c55e; outline-offset: -2px; }
+
+tr.row-skipped td { background: #f9fafb !important; opacity: 0.7; }
+tr.row-skipped td.code-b { outline: 2px solid #9ca3af; outline-offset: -2px; }
+
+.edit-status-badge {
+  font-size: 11px;
+  font-weight: 600;
+  margin-left: 6px;
+  padding: 1px 5px;
+  border-radius: 3px;
+  vertical-align: middle;
+}
+.badge-edited  { color: #15803d; background: #dcfce7; }
+.badge-skipped { color: #6b7280; background: #f3f4f6; }
+
+.edit-progress {
+  font-size: 12px;
+  color: #6b7280;
+  margin-right: 6px;
+}
+
+.send-btn {
+  font-size: 12px;
+  padding: 3px 12px;
+  border-radius: 4px;
+  border: 1px solid #2563eb;
+  background: #2563eb;
+  color: #fff;
+  cursor: pointer;
+  font-weight: 600;
+}
+.send-btn:disabled { background: #9ca3af; border-color: #9ca3af; cursor: not-allowed; }
+.send-btn:not(:disabled):hover { background: #1d4ed8; }

--- a/templates/diff.html
+++ b/templates/diff.html
@@ -25,6 +25,10 @@
       {% if changed == 0 %}<span class="badge badge-same">변경 없음</span>{% else %}<span class="badge badge-changed">{{ changed }}줄 변경</span>{% endif %}
       <!-- 변경 위치 이동 버튼: 변경된 줄이 있을 때만 표시 -->
       {% if changed > 0 %}
+      {% if has_editable %}
+      <span class="edit-progress" id="edit-progress">0 / {{ changed }} 처리됨</span>
+      <button class="send-btn" id="send-btn" disabled>서버로 전송</button>
+      {% endif %}
       <!-- 이전 변경으로 이동 (Shift+F7 단축키) -->
       <button class="nav-change-btn" id="btn-prev-change" title="이전 변경 (Shift+F7)">&#9650;</button>
       <!-- 현재 위치 / 전체 변경 수 표시 -->
@@ -79,7 +83,7 @@
         <!-- 수정본 줄 번호 (gutter) -->
         <td class="gutter gutter-b">{% if row.lineno_b is not none %}{{ row.lineno_b }}{% endif %}</td>
         <!-- 수정본 코드: 추가/변경 시 '+' 기호 표시 + 단어 단위 diff HTML -->
-        <td class="code code-b"><span class="line-mark {% if row.type == "insert" or row.type == "replace" %}line-mark-add{% endif %}">{% if row.type == "insert" or row.type == "replace" %}+{% endif %}</span><span class="line-text">{{ row.html_b|safe }}</span></td>
+        <td class="code code-b"><span class="line-mark {% if row.type == "insert" or row.type == "replace" %}line-mark-add{% endif %}">{% if row.type == "insert" or row.type == "replace" %}+{% endif %}</span><span class="line-text" id="line-text-{{ loop.index }}">{{ row.html_b|safe }}</span>{% if row.meta_b %}<span class="edit-actions"><button class="edit-action-btn edit-btn" data-row="{{ loop.index }}" data-meta="{{ row.meta_b | tojson | forceescape }}" data-original="{{ row.meta_b.value | e }}">수정</button><button class="edit-action-btn skip-btn" data-row="{{ loop.index }}" data-meta="{{ row.meta_b | tojson | forceescape }}">스킵</button></span><span class="edit-status-badge" id="badge-{{ loop.index }}" style="display:none"></span>{% endif %}</td>
       </tr>
       {% endif %}
       {% endfor %}
@@ -171,6 +175,98 @@
       });
     }
   }
+}());
+
+/* ── Edit/Skip 상태 관리 ── */
+(function() {
+  var editState = {};
+  var editBtns = document.querySelectorAll('.edit-btn');
+  var skipBtns = document.querySelectorAll('.skip-btn');
+  var totalEditable = editBtns.length;
+  var progressEl = document.getElementById('edit-progress');
+  var sendBtn = document.getElementById('send-btn');
+
+  function updateProgress() {
+    var done = Object.keys(editState).length;
+    if (progressEl) progressEl.textContent = done + ' / ' + totalEditable + ' 처리됨';
+    if (sendBtn) sendBtn.disabled = (done < totalEditable);
+  }
+
+  function setRowState(rowIdx, action, value, meta) {
+    var tr = document.querySelector('[data-row="' + rowIdx + '"]');
+    if (tr) tr = tr.closest('tr');
+    var badge = document.getElementById('badge-' + rowIdx);
+    var lineText = document.getElementById('line-text-' + rowIdx);
+
+    if (tr) tr.classList.remove('row-edited', 'row-skipped');
+    if (badge) { badge.style.display = 'none'; badge.textContent = ''; }
+
+    if (action === null) {
+      delete editState[rowIdx];
+    } else {
+      editState[rowIdx] = { action: action, value: value, meta: meta };
+      if (tr) tr.classList.add(action === 'edited' ? 'row-edited' : 'row-skipped');
+      if (badge) {
+        badge.textContent = action === 'edited' ? '✓ 수정됨' : '⊘ 스킵됨';
+        badge.className = 'edit-status-badge badge-' + (action === 'edited' ? 'edited' : 'skipped');
+        badge.style.display = 'inline';
+      }
+      if (action === 'edited' && lineText) lineText.textContent = value;
+    }
+    updateProgress();
+  }
+
+  editBtns.forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      var rowIdx = this.getAttribute('data-row');
+      var meta = JSON.parse(this.getAttribute('data-meta'));
+      var original = this.getAttribute('data-original');
+      if (editState[rowIdx] && editState[rowIdx].action === 'edited') {
+        setRowState(rowIdx, null, null, null);
+        return;
+      }
+      var newVal = prompt('값을 수정하세요:', original);
+      if (newVal === null) return;
+      setRowState(rowIdx, 'edited', newVal, meta);
+    });
+  });
+
+  skipBtns.forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      var rowIdx = this.getAttribute('data-row');
+      var meta = JSON.parse(this.getAttribute('data-meta'));
+      var lineText = document.getElementById('line-text-' + rowIdx);
+      var original = lineText ? lineText.textContent : '';
+      if (editState[rowIdx] && editState[rowIdx].action === 'skipped') {
+        setRowState(rowIdx, null, null, null);
+        return;
+      }
+      setRowState(rowIdx, 'skipped', original, meta);
+    });
+  });
+
+  if (sendBtn) {
+    sendBtn.addEventListener('click', function() {
+      var payload = Object.values(editState).map(function(s) {
+        return {
+          package_name: s.meta.package_name,
+          sub_title: s.meta.sub_title,
+          item: { id: s.meta.item_id, value: s.value, line_number: s.meta.line_number, edit_type: s.meta.edit_type },
+          user_action: s.action
+        };
+      });
+      fetch(window.location.pathname + '/submit', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      })
+      .then(function(r) { return r.json(); })
+      .then(function(data) { alert('전송 완료: ' + data.count + '건'); })
+      .catch(function(err) { alert('전송 실패: ' + err.message); });
+    });
+  }
+
+  updateProgress();
 }());
 </script>
 {% endblock %}

--- a/tests/test_xml_parser.py
+++ b/tests/test_xml_parser.py
@@ -2,7 +2,8 @@
 import sys, os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
-import textwrap, tempfile, pytest
+import textwrap
+import pytest
 from app import parse_xml_file
 
 XML_SAMPLE = textwrap.dedent("""\
@@ -92,10 +93,21 @@ def test_meta_map_second_diffitem(xml_file):
     meta = meta_map[idx]
     assert meta["item_id"] == "id_003"
     assert meta["sub_title"] == "섹션2"
+    assert meta["package_name"] == "MyPkg"
+    assert meta["value"] == "세 번째 값"
 
 
 def test_header_lines_not_in_meta_map(xml_file):
     lines, meta_map = parse_xml_file(xml_file)
     for idx, line in enumerate(lines):
-        if "MyPkg" in line or line.strip() == "":
+        if line.startswith("#########") or line.strip() == "":
             assert idx not in meta_map, f"헤더/빈 줄(인덱스 {idx})이 meta_map에 포함됨"
+
+
+def test_empty_diffitems_returns_empty(tmp_path):
+    empty_xml = '<?xml version="1.0" encoding="utf-8"?><DiffPackage><PackageName>P</PackageName><DiffItems/></DiffPackage>'
+    f = tmp_path / "empty.xml"
+    f.write_text(empty_xml, encoding="utf-8")
+    lines, meta_map = parse_xml_file(str(f))
+    assert lines == []
+    assert meta_map == {}

--- a/tests/test_xml_parser.py
+++ b/tests/test_xml_parser.py
@@ -111,3 +111,27 @@ def test_empty_diffitems_returns_empty(tmp_path):
     lines, meta_map = parse_xml_file(str(f))
     assert lines == []
     assert meta_map == {}
+
+
+from app import get_file_list
+
+def test_get_file_list_finds_xml(tmp_path):
+    # baseline 디렉토리 구조 생성
+    word_dir = tmp_path / "00.WordBase"
+    code_dir = tmp_path / "01.CodeBase"
+    word_dir.mkdir(); code_dir.mkdir()
+    (word_dir / "a.xml").write_text('<DiffPackage><PackageName>P</PackageName><DiffItems/></DiffPackage>', encoding="utf-8")
+    (code_dir / "a.xml").write_text('<DiffPackage><PackageName>P</PackageName><DiffItems/></DiffPackage>', encoding="utf-8")
+
+    import app as app_module
+    original_data_dir = app_module.DATA_DIR
+
+    baseline_name = tmp_path.name
+    parent = str(tmp_path.parent)
+    app_module.DATA_DIR = parent
+    try:
+        result = get_file_list(baseline_name)
+        filenames = [f['name'] for f in result['files']]
+        assert "a.xml" in filenames
+    finally:
+        app_module.DATA_DIR = original_data_dir

--- a/tests/test_xml_parser.py
+++ b/tests/test_xml_parser.py
@@ -4,7 +4,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 import textwrap
 import pytest
-from app import parse_xml_file
+from app import parse_xml_file, get_file_list
 
 XML_SAMPLE = textwrap.dedent("""\
     <?xml version="1.0" encoding="utf-8"?>
@@ -113,8 +113,6 @@ def test_empty_diffitems_returns_empty(tmp_path):
     assert meta_map == {}
 
 
-from app import get_file_list
-
 def test_get_file_list_finds_xml(tmp_path):
     # baseline 디렉토리 구조 생성
     word_dir = tmp_path / "00.WordBase"
@@ -122,6 +120,9 @@ def test_get_file_list_finds_xml(tmp_path):
     word_dir.mkdir(); code_dir.mkdir()
     (word_dir / "a.xml").write_text('<DiffPackage><PackageName>P</PackageName><DiffItems/></DiffPackage>', encoding="utf-8")
     (code_dir / "a.xml").write_text('<DiffPackage><PackageName>P</PackageName><DiffItems/></DiffPackage>', encoding="utf-8")
+    # .txt 파일도 생성 — 필터되어야 함
+    (word_dir / "b.txt").write_text("should be ignored", encoding="utf-8")
+    (code_dir / "b.txt").write_text("should be ignored", encoding="utf-8")
 
     import app as app_module
     original_data_dir = app_module.DATA_DIR
@@ -133,5 +134,6 @@ def test_get_file_list_finds_xml(tmp_path):
         result = get_file_list(baseline_name)
         filenames = [f['name'] for f in result['files']]
         assert "a.xml" in filenames
+        assert "b.txt" not in filenames
     finally:
         app_module.DATA_DIR = original_data_dir

--- a/tests/test_xml_parser.py
+++ b/tests/test_xml_parser.py
@@ -175,7 +175,7 @@ def test_build_diff_xml_replace_has_meta_b(tmp_path):
     (word_dir / "t.xml").write_text(WORD_XML, encoding="utf-8")
     (code_dir / "t.xml").write_text(CODE_XML, encoding="utf-8")
 
-    rows, total, changed = build_diff(str(word_dir), str(code_dir), "t.xml")
+    rows, _, _ = build_diff(str(word_dir), str(code_dir), "t.xml")
     replace_rows = [r for r in rows if r["type"] == "replace"]
     assert len(replace_rows) > 0
     for row in replace_rows:

--- a/tests/test_xml_parser.py
+++ b/tests/test_xml_parser.py
@@ -4,7 +4,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 import textwrap
 import pytest
-from app import parse_xml_file, get_file_list
+from app import parse_xml_file, get_file_list, build_diff
 
 XML_SAMPLE = textwrap.dedent("""\
     <?xml version="1.0" encoding="utf-8"?>
@@ -137,3 +137,63 @@ def test_get_file_list_finds_xml(tmp_path):
         assert "b.txt" not in filenames
     finally:
         app_module.DATA_DIR = original_data_dir
+
+
+WORD_XML = """<?xml version="1.0" encoding="utf-8"?>
+<DiffPackage>
+  <PackageName>Pkg</PackageName>
+  <DiffItems>
+    <DiffItem>
+      <SubTitle>S1</SubTitle>
+      <Items>
+        <Item><ID>a1</ID><Value>같은 내용</Value><LineNumber>1</LineNumber><EditType>None</EditType></Item>
+        <Item><ID>a2</ID><Value>원본 값</Value><LineNumber>2</LineNumber><EditType>None</EditType></Item>
+      </Items>
+    </DiffItem>
+  </DiffItems>
+</DiffPackage>"""
+
+CODE_XML = """<?xml version="1.0" encoding="utf-8"?>
+<DiffPackage>
+  <PackageName>Pkg</PackageName>
+  <DiffItems>
+    <DiffItem>
+      <SubTitle>S1</SubTitle>
+      <Items>
+        <Item><ID>a1</ID><Value>같은 내용</Value><LineNumber>1</LineNumber><EditType>None</EditType></Item>
+        <Item><ID>a2</ID><Value>수정된 값</Value><LineNumber>2</LineNumber><EditType>Modified</EditType></Item>
+      </Items>
+    </DiffItem>
+  </DiffItems>
+</DiffPackage>"""
+
+
+def test_build_diff_xml_replace_has_meta_b(tmp_path):
+    word_dir = tmp_path / "00.WordBase"
+    code_dir = tmp_path / "01.CodeBase"
+    word_dir.mkdir(); code_dir.mkdir()
+    (word_dir / "t.xml").write_text(WORD_XML, encoding="utf-8")
+    (code_dir / "t.xml").write_text(CODE_XML, encoding="utf-8")
+
+    rows, total, changed = build_diff(str(word_dir), str(code_dir), "t.xml")
+    replace_rows = [r for r in rows if r["type"] == "replace"]
+    assert len(replace_rows) > 0
+    for row in replace_rows:
+        assert row["meta_b"] is not None
+        assert "item_id" in row["meta_b"]
+        assert "sub_title" in row["meta_b"]
+        assert "package_name" in row["meta_b"]
+
+
+def test_build_diff_xml_equal_has_no_meta_b(tmp_path):
+    word_dir = tmp_path / "00.WordBase"
+    code_dir = tmp_path / "01.CodeBase"
+    word_dir.mkdir(); code_dir.mkdir()
+    (word_dir / "t.xml").write_text(WORD_XML, encoding="utf-8")
+    (code_dir / "t.xml").write_text(CODE_XML, encoding="utf-8")
+
+    rows, _, _ = build_diff(str(word_dir), str(code_dir), "t.xml")
+    equal_rows = [r for r in rows if r["type"] == "equal"]
+    assert len(equal_rows) > 0
+    for row in equal_rows:
+        assert row["meta_b"] is None

--- a/tests/test_xml_parser.py
+++ b/tests/test_xml_parser.py
@@ -1,0 +1,101 @@
+# tests/test_xml_parser.py
+import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+import textwrap, tempfile, pytest
+from app import parse_xml_file
+
+XML_SAMPLE = textwrap.dedent("""\
+    <?xml version="1.0" encoding="utf-8"?>
+    <DiffPackage>
+      <PackageName>MyPkg</PackageName>
+      <DiffItems>
+        <DiffItem>
+          <SubTitle>섹션1</SubTitle>
+          <Items>
+            <Item>
+              <ID>id_001</ID>
+              <Value>첫 번째 값</Value>
+              <LineNumber>1</LineNumber>
+              <EditType>None</EditType>
+            </Item>
+            <Item>
+              <ID>id_002</ID>
+              <Value>두 번째 값</Value>
+              <LineNumber>2</LineNumber>
+              <EditType>Modified</EditType>
+            </Item>
+          </Items>
+        </DiffItem>
+        <DiffItem>
+          <SubTitle>섹션2</SubTitle>
+          <Items>
+            <Item>
+              <ID>id_003</ID>
+              <Value>세 번째 값</Value>
+              <LineNumber>3</LineNumber>
+              <EditType>None</EditType>
+            </Item>
+          </Items>
+        </DiffItem>
+      </DiffItems>
+    </DiffPackage>
+""")
+
+
+@pytest.fixture
+def xml_file(tmp_path):
+    f = tmp_path / "sample.xml"
+    f.write_text(XML_SAMPLE, encoding="utf-8")
+    return str(f)
+
+
+def test_parse_returns_tuple(xml_file):
+    result = parse_xml_file(xml_file)
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+
+
+def test_lines_contain_package_header(xml_file):
+    lines, _ = parse_xml_file(xml_file)
+    assert any("MyPkg" in l for l in lines)
+
+
+def test_lines_contain_all_item_values(xml_file):
+    lines, _ = parse_xml_file(xml_file)
+    assert "첫 번째 값" in lines
+    assert "두 번째 값" in lines
+    assert "세 번째 값" in lines
+
+
+def test_meta_map_keys_are_int(xml_file):
+    _, meta_map = parse_xml_file(xml_file)
+    for k in meta_map:
+        assert isinstance(k, int)
+
+
+def test_meta_map_item_fields(xml_file):
+    lines, meta_map = parse_xml_file(xml_file)
+    idx = lines.index("첫 번째 값")
+    meta = meta_map[idx]
+    assert meta["item_id"] == "id_001"
+    assert meta["value"] == "첫 번째 값"
+    assert meta["line_number"] == 1
+    assert meta["edit_type"] == "None"
+    assert meta["sub_title"] == "섹션1"
+    assert meta["package_name"] == "MyPkg"
+
+
+def test_meta_map_second_diffitem(xml_file):
+    lines, meta_map = parse_xml_file(xml_file)
+    idx = lines.index("세 번째 값")
+    meta = meta_map[idx]
+    assert meta["item_id"] == "id_003"
+    assert meta["sub_title"] == "섹션2"
+
+
+def test_header_lines_not_in_meta_map(xml_file):
+    lines, meta_map = parse_xml_file(xml_file)
+    for idx, line in enumerate(lines):
+        if "MyPkg" in line or line.strip() == "":
+            assert idx not in meta_map, f"헤더/빈 줄(인덱스 {idx})이 meta_map에 포함됨"


### PR DESCRIPTION
## Summary

- `.txt` 파일 포맷을 `.xml` 포맷으로 완전 교체
- XML 파싱 후 기존 diff 엔진에 그대로 전달 (로직 변경 최소화)
- `01.CodeBase` 쪽 변경 라인에 수정/스킵 버튼 추가
- 모든 diff 라인 처리 완료 시 서버 전송 버튼 활성화
- 서버 URL은 `app.py`의 `SUBMIT_SERVER_URL` 상수에 추후 설정

## Changes

- `app.py`: `parse_xml_file`, `submit_edits` 추가, `build_diff`/`get_file_list`/`diff_view` XML 처리
- `templates/diff.html`: 수정/스킵 버튼, 진행 카운터, 전송 버튼, JS 상태 관리
- `static/style.css`: Edit/Skip 상태 스타일 추가
- `tests/test_xml_parser.py`: 11개 단위 테스트 (TDD)
- `data/baseline_v4/`: XML 테스트 데이터

## Test plan

- [ ] `pytest tests/ -v` → 11 passed
- [ ] `http://localhost:5000/baseline_v4` → `sample.xml` 목록 표시
- [ ] `sample.xml` 클릭 → diff 화면, 변경 라인에 [수정]/[스킵] 버튼 표시
- [ ] [수정] 클릭 → 값 입력 후 초록 테두리 + ✓ 수정됨 뱃지
- [ ] [스킵] 클릭 → 회색 테두리 + ⊘ 스킵됨 뱃지
- [ ] 버튼 재클릭 → 상태 초기화
- [ ] 모든 항목 처리 → "서버로 전송" 버튼 활성화
- [ ] 전송 버튼 → "전송 완료: N건" 알림

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)