### PR TITLE
feat: 수정 창을 모달로 변경 (#12)

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -808,3 +808,80 @@ tr.row-skipped td.code-b { outline: 2px solid #9ca3af; outline-offset: -2px; }
 }
 .send-btn:disabled { background: #9ca3af; border-color: #9ca3af; cursor: not-allowed; }
 .send-btn:not(:disabled):hover { background: #1d4ed8; }
+
+/* ── 수정 모달 ── */
+.edit-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+.edit-modal-box {
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.2);
+  width: 480px;
+  max-width: 90vw;
+  display: flex;
+  flex-direction: column;
+}
+.edit-modal-header {
+  font-size: 14px;
+  font-weight: 700;
+  padding: 14px 18px 10px;
+  border-bottom: 1px solid #e5e7eb;
+  color: #111827;
+}
+.edit-modal-body {
+  padding: 16px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.edit-modal-row { display: flex; flex-direction: column; gap: 4px; }
+.edit-modal-label { font-size: 11px; font-weight: 600; color: #6b7280; text-transform: uppercase; letter-spacing: .04em; }
+.edit-modal-original {
+  font-family: 'JetBrains Mono', 'Fira Code', Consolas, monospace;
+  font-size: 13px;
+  background: #f3f4f6;
+  border-radius: 4px;
+  padding: 8px 10px;
+  color: #374151;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+.edit-modal-textarea {
+  font-family: 'JetBrains Mono', 'Fira Code', Consolas, monospace;
+  font-size: 13px;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  padding: 8px 10px;
+  resize: vertical;
+  outline: none;
+  width: 100%;
+  box-sizing: border-box;
+  color: #111827;
+}
+.edit-modal-textarea:focus { border-color: #2563eb; box-shadow: 0 0 0 2px #bfdbfe; }
+.edit-modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 10px 18px 14px;
+  border-top: 1px solid #e5e7eb;
+}
+.edit-modal-btn {
+  font-size: 13px;
+  font-weight: 600;
+  padding: 5px 16px;
+  border-radius: 5px;
+  border: 1px solid transparent;
+  cursor: pointer;
+}
+.edit-modal-cancel { background: #f3f4f6; color: #374151; border-color: #d1d5db; }
+.edit-modal-cancel:hover { background: #e5e7eb; }
+.edit-modal-confirm { background: #2563eb; color: #fff; }
+.edit-modal-confirm:hover { background: #1d4ed8; }

--- a/templates/diff.html
+++ b/templates/diff.html
@@ -98,6 +98,27 @@
 
 </div>
 
+<!-- ===== 수정 모달 ===== -->
+<div id="edit-modal" class="edit-modal-overlay" style="display:none">
+  <div class="edit-modal-box">
+    <div class="edit-modal-header">값 수정</div>
+    <div class="edit-modal-body">
+      <div class="edit-modal-row">
+        <label class="edit-modal-label">원본</label>
+        <div class="edit-modal-original" id="modal-original"></div>
+      </div>
+      <div class="edit-modal-row">
+        <label class="edit-modal-label">수정 내용</label>
+        <textarea class="edit-modal-textarea" id="modal-input" rows="3"></textarea>
+      </div>
+    </div>
+    <div class="edit-modal-footer">
+      <button class="edit-modal-btn edit-modal-cancel" id="modal-cancel">취소</button>
+      <button class="edit-modal-btn edit-modal-confirm" id="modal-confirm">확인</button>
+    </div>
+  </div>
+</div>
+
 <script>
 /* ── [M4] 변경 네비게이션 + 미니맵 ──
    변경된 줄 간 이동 기능과 전체 파일 대비 변경 위치를 시각적으로 표시하는 미니맵 */
@@ -216,18 +237,57 @@
     updateProgress();
   }
 
+  var modalOverlay = document.getElementById('edit-modal');
+  var modalOriginal = document.getElementById('modal-original');
+  var modalInput = document.getElementById('modal-input');
+  var modalConfirm = document.getElementById('modal-confirm');
+  var modalCancel = document.getElementById('modal-cancel');
+  var pendingEdit = null;
+
+  function openModal(rowIdx, meta, originalText, currentText) {
+    pendingEdit = { rowIdx: rowIdx, meta: meta };
+    modalOriginal.textContent = originalText;
+    modalInput.value = currentText;
+    modalOverlay.style.display = 'flex';
+    modalInput.focus();
+    modalInput.select();
+  }
+
+  function closeModal() {
+    modalOverlay.style.display = 'none';
+    pendingEdit = null;
+  }
+
+  modalConfirm.addEventListener('click', function() {
+    if (!pendingEdit) return;
+    var val = modalInput.value;
+    setRowState(pendingEdit.rowIdx, 'edited', val, pendingEdit.meta);
+    closeModal();
+  });
+
+  modalCancel.addEventListener('click', closeModal);
+
+  modalOverlay.addEventListener('click', function(e) {
+    if (e.target === modalOverlay) closeModal();
+  });
+
+  document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape' && modalOverlay.style.display !== 'none') closeModal();
+    if (e.key === 'Enter' && e.ctrlKey && modalOverlay.style.display !== 'none') modalConfirm.click();
+  });
+
   editBtns.forEach(function(btn) {
     btn.addEventListener('click', function() {
       var rowIdx = this.getAttribute('data-row');
       var meta = JSON.parse(this.getAttribute('data-meta'));
-      var original = this.getAttribute('data-original');
+      var originalText = this.getAttribute('data-original');
       if (editState[rowIdx] && editState[rowIdx].action === 'edited') {
         setRowState(rowIdx, null, null, null);
         return;
       }
-      var newVal = prompt('값을 수정하세요:', original);
-      if (newVal === null) return;
-      setRowState(rowIdx, 'edited', newVal, meta);
+      var lineText = document.getElementById('line-text-' + rowIdx);
+      var currentText = (editState[rowIdx] && editState[rowIdx].value) || (lineText ? lineText.textContent : originalText);
+      openModal(rowIdx, meta, originalText, currentText);
     });
   });
 


### PR DESCRIPTION
## Summary

- 수정 버튼 클릭 시 브라우저 `prompt()` 대신 커스텀 모달 창 표시
- **원본** 항목: 원래 XML 값을 읽기 전용으로 표시
- **수정 내용** 항목: 현재 시현 중인 값(마지막 수정값 또는 원본)을 입력창에 기본값으로 채워줌
- Esc / 오버레이 클릭으로 모달 닫기
- Ctrl+Enter로 확인

## Test plan

- [ ] [수정] 버튼 클릭 → 모달 열림
- [ ] 원본 칸에 원래 XML 값 표시 확인
- [ ] 입력창에 현재 시현 중인 값 기본값으로 채워짐 확인
- [ ] 값 수정 후 확인 → diff 행에 반영, ✓ 수정됨 뱃지 표시
- [ ] Esc / 오버레이 클릭 → 모달 닫힘
- [ ] Ctrl+Enter → 확인 동작

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)